### PR TITLE
validate content size a la ssb-validate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,5 @@
 .vscode
 node_modules
 pnpm-lock.yaml
+package-lock.json
 coverage
-*~

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2022 Andre 'Staltz' Medeiros
+#
+# SPDX-License-Identifier: CC0-1.0
+
+semi: false
+singleQuote: true

--- a/format.js
+++ b/format.js
@@ -2,43 +2,43 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const Ref = require('ssb-ref');
-const bipf = require('bipf');
-const ssbKeys = require('ssb-keys');
+const Ref = require('ssb-ref')
+const bipf = require('bipf')
+const ssbKeys = require('ssb-keys')
 const {
   validate,
   validateOOO,
   validateBatch,
   validateOOOBatch,
   validateContent,
-} = require('./validation');
-const getMsgId = require('./get-msg-id');
+} = require('./validation')
+const getMsgId = require('./get-msg-id')
 
-const name = 'classic';
-const encodings = ['js', 'bipf'];
+const name = 'classic'
+const encodings = ['js', 'bipf']
 
 function getFeedId(nativeMsg) {
-  return nativeMsg.author;
+  return nativeMsg.author
 }
 
 function getSequence(nativeMsg) {
-  return nativeMsg.sequence;
+  return nativeMsg.sequence
 }
 
 function isNativeMsg(x) {
-  return typeof x === 'object' && !!x && Ref.isFeedId(x.author);
+  return typeof x === 'object' && !!x && Ref.isFeedId(x.author)
 }
 
 function isAuthor(author) {
-  return Ref.isFeedId(author);
+  return Ref.isFeedId(author)
 }
 
 function toPlaintextBuffer(opts) {
-  return Buffer.from(JSON.stringify(opts.content), 'utf8');
+  return Buffer.from(JSON.stringify(opts.content), 'utf8')
 }
 
 function newNativeMsg(opts) {
-  const previous = opts.previous || {key: null, value: {sequence: 0}};
+  const previous = opts.previous || { key: null, value: { sequence: 0 } }
   const nativeMsg = {
     previous: previous.key,
     sequence: previous.value.sequence + 1,
@@ -46,17 +46,17 @@ function newNativeMsg(opts) {
     timestamp: +opts.timestamp,
     hash: 'sha256',
     content: opts.content,
-  };
-  let err;
-  if ((err = validateContent(nativeMsg))) throw err;
-  return ssbKeys.signObj(opts.keys, opts.hmacKey, nativeMsg);
+  }
+  let err
+  if ((err = validateContent(nativeMsg))) throw err
+  return ssbKeys.signObj(opts.keys, opts.hmacKey, nativeMsg)
 }
 
 function fromNativeMsg(nativeMsg, encoding = 'js') {
   if (encoding === 'js') {
-    return nativeMsg;
+    return nativeMsg
   } else if (encoding === 'bipf') {
-    return bipf.allocAndEncode(nativeMsg);
+    return bipf.allocAndEncode(nativeMsg)
   } else {
     // prettier-ignore
     throw new Error(`Feed format "${name}" does not support encoding "${encoding}"`)
@@ -65,14 +65,14 @@ function fromNativeMsg(nativeMsg, encoding = 'js') {
 
 function fromDecryptedNativeMsg(plaintextBuf, nativeMsg, encoding = 'js') {
   if (encoding === 'js') {
-    const msgVal = nativeMsg;
-    const content = JSON.parse(plaintextBuf.toString('utf8'));
-    msgVal.content = content;
-    return msgVal;
+    const msgVal = nativeMsg
+    const content = JSON.parse(plaintextBuf.toString('utf8'))
+    msgVal.content = content
+    return msgVal
   } else if (encoding === 'bipf') {
     return bipf.allocAndEncode(
-      fromDecryptedNativeMsg(plaintextBuf, nativeMsg, 'js'),
-    );
+      fromDecryptedNativeMsg(plaintextBuf, nativeMsg, 'js')
+    )
   } else {
     // prettier-ignore
     throw new Error(`Feed format "${name}" does not support encoding "${encoding}"`)
@@ -81,9 +81,9 @@ function fromDecryptedNativeMsg(plaintextBuf, nativeMsg, encoding = 'js') {
 
 function toNativeMsg(msg, encoding = 'js') {
   if (encoding === 'js') {
-    return msg;
+    return msg
   } else if (encoding === 'bipf') {
-    return bipf.decode(msg);
+    return bipf.decode(msg)
   } else {
     // prettier-ignore
     throw new Error(`Feed format "${name}" does not support encoding "${encoding}"`)
@@ -107,4 +107,4 @@ module.exports = {
   validateOOO,
   validateBatch,
   validateOOOBatch,
-};
+}

--- a/get-msg-id.js
+++ b/get-msg-id.js
@@ -2,15 +2,15 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const ssbKeys = require('ssb-keys');
+const ssbKeys = require('ssb-keys')
 
-const _msgIdCache = new Map();
+const _msgIdCache = new Map()
 
 module.exports = function getMsgId(nativeMsg) {
   if (_msgIdCache.has(nativeMsg)) {
-    return _msgIdCache.get(nativeMsg);
+    return _msgIdCache.get(nativeMsg)
   }
-  const msgId = '%' + ssbKeys.hash(JSON.stringify(nativeMsg, null, 2));
-  _msgIdCache.set(nativeMsg, msgId);
-  return msgId;
-};
+  const msgId = '%' + ssbKeys.hash(JSON.stringify(nativeMsg, null, 2))
+  _msgIdCache.set(nativeMsg, msgId)
+  return msgId
+}

--- a/index.js
+++ b/index.js
@@ -3,5 +3,5 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 
 module.exports = function init(ssb) {
-  if (ssb.db) ssb.db.installFeedFormat(require('./format'));
-};
+  if (ssb.db) ssb.db.installFeedFormat(require('./format'))
+}

--- a/test/validate.js
+++ b/test/validate.js
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2022 Mix Irving
+//
+// SPDX-License-Identifier: CC0-1.0
+
+const test = require('tape');
+const { validate } = require('../validation');
+
+test('validate "too big"', (t) => {
+  const Msg = (content) => ({
+    previous: null,
+    sequence: 1,
+    author: '@someFeed00someFeed00someFeed00someFeed0011A=.ed25519',
+    timestamp: 12312312312,
+    hash: 'sha256',
+    content,
+    signature: '234234232334'
+  })
+  const msg1 = Msg({
+    type: 'post',
+    text: Array(10000).fill('!').join('')
+  })
+  const msg2 = Msg(Array(10000).fill('!').join('') + '.box2')
+
+  validate(msg1, null, null, (err) => {
+    t.match(
+      err && err.message,
+      /content must be at most 8192/,
+      'plaintext oversized message invalid'
+    )
+
+    validate(msg2, null, null, (err) => {
+      t.match(
+        err && err.message,
+        /content must be at most 8192/,
+        'encrypted oversized message invalid'
+      )
+      t.end()
+    })
+  })
+})

--- a/validation.js
+++ b/validation.js
@@ -184,7 +184,7 @@ function validateContent(msgVal) {
     const size = JSON.stringify(content, null, 2).length
     if (size > SIZE_LIMIT) {
       return new Error(
-        'invalid message: encoded content must be less than 8192 characters. Current size is ' +
+        'invalid message: encoded content must be at most 8192 characters. Current size is ' +
           size
       )
     }

--- a/validation.js
+++ b/validation.js
@@ -2,53 +2,53 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const Ref = require("ssb-ref");
-const ssbKeys = require("ssb-keys");
-const isCanonicalBase64 = require("is-canonical-base64");
-const getMsgId = require("./get-msg-id");
+const Ref = require('ssb-ref')
+const ssbKeys = require('ssb-keys')
+const isCanonicalBase64 = require('is-canonical-base64')
+const getMsgId = require('./get-msg-id')
 
-const isSignatureRx = isCanonicalBase64("", "\\.sig.\\w+");
-const SIZE_LIMIT = 8192; // max "encoded character" size limit of classic message
+const isSignatureRx = isCanonicalBase64('', '\\.sig.\\w+')
+const SIZE_LIMIT = 8192 // max "encoded character" size limit of classic message
 
 function validateShape(msgVal) {
-  if (!msgVal || typeof msgVal !== "object") {
-    return new Error("invalid message: not a classic msg");
+  if (!msgVal || typeof msgVal !== 'object') {
+    return new Error('invalid message: not a classic msg')
   }
-  if (typeof msgVal.author === "undefined") {
-    return new Error("invalid message: must have author");
+  if (typeof msgVal.author === 'undefined') {
+    return new Error('invalid message: must have author')
   }
-  if (typeof msgVal.previous === "undefined") {
-    return new Error("invalid message: must have previous");
+  if (typeof msgVal.previous === 'undefined') {
+    return new Error('invalid message: must have previous')
   }
-  if (typeof msgVal.sequence === "undefined") {
-    return new Error("invalid message: must have sequence");
+  if (typeof msgVal.sequence === 'undefined') {
+    return new Error('invalid message: must have sequence')
   }
-  if (typeof msgVal.timestamp === "undefined") {
-    return new Error("invalid message: must have timestamp");
+  if (typeof msgVal.timestamp === 'undefined') {
+    return new Error('invalid message: must have timestamp')
   }
-  if (typeof msgVal.hash === "undefined") {
-    return new Error("invalid message: must have hash");
+  if (typeof msgVal.hash === 'undefined') {
+    return new Error('invalid message: must have hash')
   }
-  if (typeof msgVal.content === "undefined") {
-    return new Error("invalid message: must have content");
+  if (typeof msgVal.content === 'undefined') {
+    return new Error('invalid message: must have content')
   }
-  if (typeof msgVal.signature === "undefined") {
-    return new Error("invalid message: must have signature");
+  if (typeof msgVal.signature === 'undefined') {
+    return new Error('invalid message: must have signature')
   }
 }
 
 function validateAuthor(msgVal) {
   if (!Ref.isFeedId(msgVal.author)) {
-    return new Error("invalid message: must have author as a sigil ID");
+    return new Error('invalid message: must have author as a sigil ID')
   }
 }
 
 function validateSignature(msgVal, hmacKey) {
-  const { signature } = msgVal;
-  if (typeof signature !== "string") {
-    return new Error("invalid message: must have signature as a string");
+  const { signature } = msgVal
+  if (typeof signature !== 'string') {
+    return new Error('invalid message: must have signature as a string')
   }
-  if (!signature.endsWith(".sig.ed25519")) {
+  if (!signature.endsWith('.sig.ed25519')) {
     // prettier-ignore
     return new Error('invalid message: signature must end with .sig.ed25519')
   }
@@ -61,7 +61,7 @@ function validateSignature(msgVal, hmacKey) {
     return new Error('invalid message: signature must be 64 bytes, on feed: ' + msgVal.author);
   }
 
-  const keys = { public: msgVal.author.substring(1) };
+  const keys = { public: msgVal.author.substring(1) }
   if (!ssbKeys.verifyObj(keys, hmacKey, msgVal)) {
     // prettier-ignore
     return new Error('invalid message: signature does not match, on feed: ' + msgVal.author);
@@ -69,32 +69,32 @@ function validateSignature(msgVal, hmacKey) {
 }
 
 function validateOrder(msgVal) {
-  const keys = Object.keys(msgVal);
+  const keys = Object.keys(msgVal)
   if (keys.length !== 7) {
-    return new Error("invalid message: wrong number of object fields");
+    return new Error('invalid message: wrong number of object fields')
   }
   if (
-    keys[0] !== "previous" ||
-    keys[3] !== "timestamp" ||
-    keys[4] !== "hash" ||
-    keys[5] !== "content" ||
-    keys[6] !== "signature"
+    keys[0] !== 'previous' ||
+    keys[3] !== 'timestamp' ||
+    keys[4] !== 'hash' ||
+    keys[5] !== 'content' ||
+    keys[6] !== 'signature'
   ) {
-    return new Error("invalid message: wrong order of object fields");
+    return new Error('invalid message: wrong order of object fields')
   }
   // author and sequence may be swapped.
   if (
     !(
-      (keys[1] === "sequence" && keys[2] === "author") ||
-      (keys[1] === "author" && keys[2] === "sequence")
+      (keys[1] === 'sequence' && keys[2] === 'author') ||
+      (keys[1] === 'author' && keys[2] === 'sequence')
     )
   ) {
-    return new Error("invalid message: wrong order of object fields");
+    return new Error('invalid message: wrong order of object fields')
   }
 }
 
 function validatePrevious(msgVal, prevMsgVal) {
-  const prevMsgId = prevMsgVal.id ? prevMsgVal.id : getMsgId(prevMsgVal);
+  const prevMsgId = prevMsgVal.id ? prevMsgVal.id : getMsgId(prevMsgVal)
   if (msgVal.previous !== prevMsgId) {
     // prettier-ignore
     return new Error('invalid message: expected different previous message, on feed: ' + msgVal.author);
@@ -116,12 +116,12 @@ function validateFirstSequence(msgVal) {
 }
 
 function validateSequence(msgVal, prevMsgVal) {
-  const { sequence } = msgVal;
+  const { sequence } = msgVal
   if (!Number.isInteger(sequence)) {
     // prettier-ignore
     return new Error('invalid message: sequence must be a number on feed: ' + msgVal.author);
   }
-  const next = prevMsgVal.sequence + 1;
+  const next = prevMsgVal.sequence + 1
   if (sequence !== next) {
     // prettier-ignore
     return new Error('invalid message: expected sequence ' + next + ' but got: ' + sequence + ' on feed: ' + msgVal.author);
@@ -129,47 +129,47 @@ function validateSequence(msgVal, prevMsgVal) {
 }
 
 function validateTimestamp(msgVal) {
-  if (typeof msgVal.timestamp !== "number") {
+  if (typeof msgVal.timestamp !== 'number') {
     // prettier-ignore
     return new Error('initial message must have timestamp, on feed: ' + msgVal.author);
   }
 }
 
 function validateHash(msgVal) {
-  if (msgVal.hash !== "sha256") {
+  if (msgVal.hash !== 'sha256') {
     // prettier-ignore
     return new Error('invalid message: hash must be sha256, on feed: ' + msgVal.author);
   }
 }
 
 function validateContent(msgVal) {
-  const { content } = msgVal;
+  const { content } = msgVal
   if (!content) {
-    return new Error("invalid message: must have content");
+    return new Error('invalid message: must have content')
   }
   if (Array.isArray(content)) {
-    return new Error("invalid message: content must not be an array");
+    return new Error('invalid message: content must not be an array')
   }
-  if (typeof content !== "object" && typeof content !== "string") {
+  if (typeof content !== 'object' && typeof content !== 'string') {
     // prettier-ignore
     return new Error('invalid message: content must be an object or string, on feed: ' + msgVal.author);
   }
-  if (typeof content === "string") {
-    if (!content.endsWith(".box") && !content.endsWith(".box2")) {
+  if (typeof content === 'string') {
+    if (!content.endsWith('.box') && !content.endsWith('.box2')) {
       return new Error(
-        "invalid message: string content must end with .box or .box2, on feed: " +
+        'invalid message: string content must end with .box or .box2, on feed: ' +
           msgVal.author
-      );
+      )
     }
     if (content.length > SIZE_LIMIT) {
       return new Error(
-        "invalid message: string content must be less than 8192 characters. Current size is " +
+        'invalid message: string content must be less than 8192 characters. Current size is ' +
           content.length
-      );
+      )
     }
   }
-  if (typeof content === "object") {
-    if (!content.type || typeof content.type !== "string") {
+  if (typeof content === 'object') {
+    if (!content.type || typeof content.type !== 'string') {
       // prettier-ignore
       return new Error('invalid message: content must have type, on feed: ' + msgVal.author);
     }
@@ -181,36 +181,36 @@ function validateContent(msgVal) {
       // prettier-ignore
       return new Error('invalid message: content type must be longer than 2 characters, on feed: ' + msgVal.author);
     }
-    const size = JSON.stringify(content, null, 2).length;
+    const size = JSON.stringify(content, null, 2).length
     if (size > SIZE_LIMIT) {
       return new Error(
-        "invalid message: encoded content must be less than 8192 characters. Current size is " +
+        'invalid message: encoded content must be less than 8192 characters. Current size is ' +
           size
-      );
+      )
     }
   }
 }
 
 function validateHmac(hmacKey) {
-  if (!hmacKey) return;
-  if (typeof hmacKey !== "string" && !Buffer.isBuffer(hmacKey)) {
-    return new Error("invalid hmac key: must be a string or buffer");
+  if (!hmacKey) return
+  if (typeof hmacKey !== 'string' && !Buffer.isBuffer(hmacKey)) {
+    return new Error('invalid hmac key: must be a string or buffer')
   }
   const bytes = Buffer.isBuffer(hmacKey)
     ? hmacKey
-    : Buffer.from(hmacKey, "base64");
+    : Buffer.from(hmacKey, 'base64')
 
-  if (typeof hmacKey === "string" && bytes.toString("base64") !== hmacKey) {
-    return new Error("invalid hmac");
+  if (typeof hmacKey === 'string' && bytes.toString('base64') !== hmacKey) {
+    return new Error('invalid hmac')
   }
 
   if (bytes.length !== 32) {
-    return new Error("invalid hmac, it should have 32 bytes");
+    return new Error('invalid hmac, it should have 32 bytes')
   }
 }
 
 function validateAsJSON(msgVal) {
-  const asJson = JSON.stringify(msgVal, null, 2);
+  const asJson = JSON.stringify(msgVal, null, 2)
   if (asJson.length > 8192) {
     // prettier-ignore
     return new Error('invalid message: message is longer than 8192 latin1 codepoints');
@@ -218,72 +218,72 @@ function validateAsJSON(msgVal) {
 }
 
 function validateSync(nativeMsg, prevNativeMsg, hmacKey) {
-  let err;
-  if ((err = validateShape(nativeMsg))) return err;
-  if ((err = validateHmac(hmacKey))) return err;
-  if ((err = validateAuthor(nativeMsg))) return err;
-  if ((err = validateHash(nativeMsg))) return err;
-  if ((err = validateTimestamp(nativeMsg))) return err;
+  let err
+  if ((err = validateShape(nativeMsg))) return err
+  if ((err = validateHmac(hmacKey))) return err
+  if ((err = validateAuthor(nativeMsg))) return err
+  if ((err = validateHash(nativeMsg))) return err
+  if ((err = validateTimestamp(nativeMsg))) return err
   if (prevNativeMsg) {
-    if ((err = validatePrevious(nativeMsg, prevNativeMsg))) return err;
-    if ((err = validateSequence(nativeMsg, prevNativeMsg))) return err;
+    if ((err = validatePrevious(nativeMsg, prevNativeMsg))) return err
+    if ((err = validateSequence(nativeMsg, prevNativeMsg))) return err
   } else {
-    if ((err = validateFirstPrevious(nativeMsg))) return err;
-    if ((err = validateFirstSequence(nativeMsg))) return err;
+    if ((err = validateFirstPrevious(nativeMsg))) return err
+    if ((err = validateFirstSequence(nativeMsg))) return err
   }
-  if ((err = validateOrder(nativeMsg))) return err;
-  if ((err = validateContent(nativeMsg))) return err;
-  if ((err = validateAsJSON(nativeMsg))) return err;
-  if ((err = validateSignature(nativeMsg, hmacKey))) return err;
+  if ((err = validateOrder(nativeMsg))) return err
+  if ((err = validateContent(nativeMsg))) return err
+  if ((err = validateAsJSON(nativeMsg))) return err
+  if ((err = validateSignature(nativeMsg, hmacKey))) return err
 }
 
 function validateOOOSync(nativeMsg, hmacKey) {
-  let err;
-  if ((err = validateShape(nativeMsg))) return err;
-  if ((err = validateHmac(hmacKey))) return err;
-  if ((err = validateAuthor(nativeMsg))) return err;
-  if ((err = validateHash(nativeMsg))) return err;
-  if ((err = validateTimestamp(nativeMsg))) return err;
-  if ((err = validateOrder(nativeMsg))) return err;
-  if ((err = validateContent(nativeMsg))) return err;
-  if ((err = validateAsJSON(nativeMsg))) return err;
-  if ((err = validateSignature(nativeMsg, hmacKey))) return err;
+  let err
+  if ((err = validateShape(nativeMsg))) return err
+  if ((err = validateHmac(hmacKey))) return err
+  if ((err = validateAuthor(nativeMsg))) return err
+  if ((err = validateHash(nativeMsg))) return err
+  if ((err = validateTimestamp(nativeMsg))) return err
+  if ((err = validateOrder(nativeMsg))) return err
+  if ((err = validateContent(nativeMsg))) return err
+  if ((err = validateAsJSON(nativeMsg))) return err
+  if ((err = validateSignature(nativeMsg, hmacKey))) return err
 }
 
 function validate(nativeMsg, prevNativeMsg, hmacKey, cb) {
-  let err;
+  let err
   if ((err = validateSync(nativeMsg, prevNativeMsg, hmacKey))) {
-    return cb(err);
+    return cb(err)
   }
-  cb();
+  cb()
 }
 
 function validateOOO(nativeMsg, hmacKey, cb) {
-  let err;
+  let err
   if ((err = validateOOOSync(nativeMsg, hmacKey))) {
-    return cb(err);
+    return cb(err)
   }
-  cb();
+  cb()
 }
 
 function validateBatch(nativeMsgs, prevNativeMsg, hmacKey, cb) {
-  let err;
-  let prev = prevNativeMsg;
+  let err
+  let prev = prevNativeMsg
   for (const nativeMsg of nativeMsgs) {
-    err = validateSync(nativeMsg, prev, hmacKey);
-    if (err) return cb(err);
-    prev = nativeMsg;
+    err = validateSync(nativeMsg, prev, hmacKey)
+    if (err) return cb(err)
+    prev = nativeMsg
   }
-  cb();
+  cb()
 }
 
 function validateOOOBatch(nativeMsgs, hmacKey, cb) {
-  let err;
+  let err
   for (const nativeMsg of nativeMsgs) {
-    err = validateOOOSync(nativeMsg, hmacKey);
-    if (err) return cb(err);
+    err = validateOOOSync(nativeMsg, hmacKey)
+    if (err) return cb(err)
   }
-  cb();
+  cb()
 }
 
 module.exports = {
@@ -292,4 +292,4 @@ module.exports = {
   validateOOO,
   validateOOOBatch,
   validateContent,
-};
+}

--- a/validation.js
+++ b/validation.js
@@ -163,7 +163,7 @@ function validateContent(msgVal) {
     }
     if (content.length > SIZE_LIMIT) {
       return new Error(
-        'invalid message: string content must be less than 8192 characters. Current size is ' +
+        'invalid message: string content must be at most 8192 characters. Current size is ' +
           content.length
       )
     }

--- a/validation.js
+++ b/validation.js
@@ -2,52 +2,53 @@
 //
 // SPDX-License-Identifier: LGPL-3.0-only
 
-const Ref = require('ssb-ref');
-const ssbKeys = require('ssb-keys');
-const isCanonicalBase64 = require('is-canonical-base64');
-const getMsgId = require('./get-msg-id');
+const Ref = require("ssb-ref");
+const ssbKeys = require("ssb-keys");
+const isCanonicalBase64 = require("is-canonical-base64");
+const getMsgId = require("./get-msg-id");
 
-const isSignatureRx = isCanonicalBase64('', '\\.sig.\\w+');
+const isSignatureRx = isCanonicalBase64("", "\\.sig.\\w+");
+const SIZE_LIMIT = 8192; // max "encoded character" size limit of classic message
 
 function validateShape(msgVal) {
-  if (!msgVal || typeof msgVal !== 'object') {
-    return new Error('invalid message: not a classic msg');
+  if (!msgVal || typeof msgVal !== "object") {
+    return new Error("invalid message: not a classic msg");
   }
-  if (typeof msgVal.author === 'undefined') {
-    return new Error('invalid message: must have author');
+  if (typeof msgVal.author === "undefined") {
+    return new Error("invalid message: must have author");
   }
-  if (typeof msgVal.previous === 'undefined') {
-    return new Error('invalid message: must have previous');
+  if (typeof msgVal.previous === "undefined") {
+    return new Error("invalid message: must have previous");
   }
-  if (typeof msgVal.sequence === 'undefined') {
-    return new Error('invalid message: must have sequence');
+  if (typeof msgVal.sequence === "undefined") {
+    return new Error("invalid message: must have sequence");
   }
-  if (typeof msgVal.timestamp === 'undefined') {
-    return new Error('invalid message: must have timestamp');
+  if (typeof msgVal.timestamp === "undefined") {
+    return new Error("invalid message: must have timestamp");
   }
-  if (typeof msgVal.hash === 'undefined') {
-    return new Error('invalid message: must have hash');
+  if (typeof msgVal.hash === "undefined") {
+    return new Error("invalid message: must have hash");
   }
-  if (typeof msgVal.content === 'undefined') {
-    return new Error('invalid message: must have content');
+  if (typeof msgVal.content === "undefined") {
+    return new Error("invalid message: must have content");
   }
-  if (typeof msgVal.signature === 'undefined') {
-    return new Error('invalid message: must have signature');
+  if (typeof msgVal.signature === "undefined") {
+    return new Error("invalid message: must have signature");
   }
 }
 
 function validateAuthor(msgVal) {
   if (!Ref.isFeedId(msgVal.author)) {
-    return new Error('invalid message: must have author as a sigil ID');
+    return new Error("invalid message: must have author as a sigil ID");
   }
 }
 
 function validateSignature(msgVal, hmacKey) {
-  const {signature} = msgVal;
-  if (typeof signature !== 'string') {
-    return new Error('invalid message: must have signature as a string');
+  const { signature } = msgVal;
+  if (typeof signature !== "string") {
+    return new Error("invalid message: must have signature as a string");
   }
-  if (!signature.endsWith('.sig.ed25519')) {
+  if (!signature.endsWith(".sig.ed25519")) {
     // prettier-ignore
     return new Error('invalid message: signature must end with .sig.ed25519')
   }
@@ -60,7 +61,7 @@ function validateSignature(msgVal, hmacKey) {
     return new Error('invalid message: signature must be 64 bytes, on feed: ' + msgVal.author);
   }
 
-  const keys = {public: msgVal.author.substring(1)};
+  const keys = { public: msgVal.author.substring(1) };
   if (!ssbKeys.verifyObj(keys, hmacKey, msgVal)) {
     // prettier-ignore
     return new Error('invalid message: signature does not match, on feed: ' + msgVal.author);
@@ -70,25 +71,25 @@ function validateSignature(msgVal, hmacKey) {
 function validateOrder(msgVal) {
   const keys = Object.keys(msgVal);
   if (keys.length !== 7) {
-    return new Error('invalid message: wrong number of object fields');
+    return new Error("invalid message: wrong number of object fields");
   }
   if (
-    keys[0] !== 'previous' ||
-    keys[3] !== 'timestamp' ||
-    keys[4] !== 'hash' ||
-    keys[5] !== 'content' ||
-    keys[6] !== 'signature'
+    keys[0] !== "previous" ||
+    keys[3] !== "timestamp" ||
+    keys[4] !== "hash" ||
+    keys[5] !== "content" ||
+    keys[6] !== "signature"
   ) {
-    return new Error('invalid message: wrong order of object fields');
+    return new Error("invalid message: wrong order of object fields");
   }
   // author and sequence may be swapped.
   if (
     !(
-      (keys[1] === 'sequence' && keys[2] === 'author') ||
-      (keys[1] === 'author' && keys[2] === 'sequence')
+      (keys[1] === "sequence" && keys[2] === "author") ||
+      (keys[1] === "author" && keys[2] === "sequence")
     )
   ) {
-    return new Error('invalid message: wrong order of object fields');
+    return new Error("invalid message: wrong order of object fields");
   }
 }
 
@@ -115,7 +116,7 @@ function validateFirstSequence(msgVal) {
 }
 
 function validateSequence(msgVal, prevMsgVal) {
-  const {sequence} = msgVal;
+  const { sequence } = msgVal;
   if (!Number.isInteger(sequence)) {
     // prettier-ignore
     return new Error('invalid message: sequence must be a number on feed: ' + msgVal.author);
@@ -128,41 +129,47 @@ function validateSequence(msgVal, prevMsgVal) {
 }
 
 function validateTimestamp(msgVal) {
-  if (typeof msgVal.timestamp !== 'number') {
+  if (typeof msgVal.timestamp !== "number") {
     // prettier-ignore
     return new Error('initial message must have timestamp, on feed: ' + msgVal.author);
   }
 }
 
 function validateHash(msgVal) {
-  if (msgVal.hash !== 'sha256') {
+  if (msgVal.hash !== "sha256") {
     // prettier-ignore
     return new Error('invalid message: hash must be sha256, on feed: ' + msgVal.author);
   }
 }
 
 function validateContent(msgVal) {
-  const {content} = msgVal;
+  const { content } = msgVal;
   if (!content) {
-    return new Error('invalid message: must have content');
+    return new Error("invalid message: must have content");
   }
   if (Array.isArray(content)) {
-    return new Error('invalid message: content must not be an array');
+    return new Error("invalid message: content must not be an array");
   }
-  if (typeof content !== 'object' && typeof content !== 'string') {
+  if (typeof content !== "object" && typeof content !== "string") {
     // prettier-ignore
     return new Error('invalid message: content must be an object or string, on feed: ' + msgVal.author);
   }
-  if (
-    typeof content === 'string' &&
-    !content.endsWith('.box') &&
-    !content.endsWith('.box2')
-  ) {
-    // prettier-ignore
-    return new Error('invalid message: string content must end with .box or .box2, on feed: ' + msgVal.author);
+  if (typeof content === "string") {
+    if (!content.endsWith(".box") && !content.endsWith(".box2")) {
+      return new Error(
+        "invalid message: string content must end with .box or .box2, on feed: " +
+          msgVal.author
+      );
+    }
+    if (content.length > SIZE_LIMIT) {
+      return new Error(
+        "invalid message: string content must be less than 8192 characters. Current size is " +
+          content.length
+      );
+    }
   }
-  if (typeof content === 'object') {
-    if (!content.type || typeof content.type !== 'string') {
+  if (typeof content === "object") {
+    if (!content.type || typeof content.type !== "string") {
       // prettier-ignore
       return new Error('invalid message: content must have type, on feed: ' + msgVal.author);
     }
@@ -174,24 +181,31 @@ function validateContent(msgVal) {
       // prettier-ignore
       return new Error('invalid message: content type must be longer than 2 characters, on feed: ' + msgVal.author);
     }
+    const size = JSON.stringify(content, null, 2).length;
+    if (size > SIZE_LIMIT) {
+      return new Error(
+        "invalid message: encoded content must be less than 8192 characters. Current size is " +
+          size
+      );
+    }
   }
 }
 
 function validateHmac(hmacKey) {
   if (!hmacKey) return;
-  if (typeof hmacKey !== 'string' && !Buffer.isBuffer(hmacKey)) {
-    return new Error('invalid hmac key: must be a string or buffer');
+  if (typeof hmacKey !== "string" && !Buffer.isBuffer(hmacKey)) {
+    return new Error("invalid hmac key: must be a string or buffer");
   }
   const bytes = Buffer.isBuffer(hmacKey)
     ? hmacKey
-    : Buffer.from(hmacKey, 'base64');
+    : Buffer.from(hmacKey, "base64");
 
-  if (typeof hmacKey === 'string' && bytes.toString('base64') !== hmacKey) {
-    return new Error('invalid hmac');
+  if (typeof hmacKey === "string" && bytes.toString("base64") !== hmacKey) {
+    return new Error("invalid hmac");
   }
 
   if (bytes.length !== 32) {
-    return new Error('invalid hmac, it should have 32 bytes');
+    return new Error("invalid hmac, it should have 32 bytes");
   }
 }
 


### PR DESCRIPTION
# :fire: :bug: 

this module has been letting messages through that other peers consider invalid.
The reference implementation put a cap on the content size, see https://github.com/ssbc/ssb-validate/blob/main/index.js#L111

It appears that this module has not honoured that.
This means that there will likely be messages in the wild which are invalid for some peers and valid for others.

I think we need to consider how to handle that given it might have far reaching + feed-killing effects